### PR TITLE
Add velocities to the status message

### DIFF
--- a/isaac_ros_vda5050_nav2_client/CMakeLists.txt
+++ b/isaac_ros_vda5050_nav2_client/CMakeLists.txt
@@ -45,6 +45,7 @@ message( STATUS "Architecture: ${ARCHITECTURE}" )
 set(CUDA_MIN_VERSION "11.4")
 
 # find dependencies
+find_package(nav_msgs)
 find_package(nav2_msgs)
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()

--- a/isaac_ros_vda5050_nav2_client/include/isaac_ros_vda5050_nav2_client/vda5050_nav2_client_node.hpp
+++ b/isaac_ros_vda5050_nav2_client/include/isaac_ros_vda5050_nav2_client/vda5050_nav2_client_node.hpp
@@ -122,8 +122,7 @@ private:
   void BatteryStateCallback(const sensor_msgs::msg::BatteryState::ConstSharedPtr msg);
   // The callback function when the node receives a nav_msgs/Odometry message and appends it's velotity to
   // the status message's velocity that gets published
-  void OdometryCallback(const nav_msgs::msg::Odometry::ConstSharedPtr msg);
-    
+  void OdometryCallback(const nav_msgs::msg::Odometry::ConstSharedPtr msg); 
   // Goal response callback for NavigateThroughPoses goal message
   void NavPoseGoalResponseCallback(
     const rclcpp_action::ClientGoalHandle<NavThroughPoses>::SharedPtr & goal);

--- a/isaac_ros_vda5050_nav2_client/include/isaac_ros_vda5050_nav2_client/vda5050_nav2_client_node.hpp
+++ b/isaac_ros_vda5050_nav2_client/include/isaac_ros_vda5050_nav2_client/vda5050_nav2_client_node.hpp
@@ -37,6 +37,7 @@
 
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "sensor_msgs/msg/battery_state.hpp"
+#include "nav_msgs/msg/odometry.hpp"
 #include "nav2_msgs/action/navigate_through_poses.hpp"
 #include "std_msgs/msg/string.hpp"
 #include "tf2_ros/transform_listener.h"
@@ -87,6 +88,8 @@ private:
     instant_actions_sub_;
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr info_sub_;
   rclcpp::Subscription<sensor_msgs::msg::BatteryState>::SharedPtr battery_state_sub_;
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odometry_sub_;
+
   // Publish a vda5050_msgs/AGVState based on the current state of the robot
   void PublishRobotState();
   // Timer callback function to publish a vda5050_msgs/AGVState message
@@ -117,6 +120,10 @@ private:
   // The callback function when the node receives a sensor_msgs/BatteryState message and processes
   // it into a VDA5050 BatteryState message
   void BatteryStateCallback(const sensor_msgs::msg::BatteryState::ConstSharedPtr msg);
+  // The callback function when the node receives a nav_msgs/Odometry message and appends it's velotity to
+  // the status message's velocity that gets published
+  void OdometryCallback(const nav_msgs::msg::Odometry::ConstSharedPtr msg);
+    
   // Goal response callback for NavigateThroughPoses goal message
   void NavPoseGoalResponseCallback(
     const rclcpp_action::ClientGoalHandle<NavThroughPoses>::SharedPtr & goal);

--- a/isaac_ros_vda5050_nav2_client/package.xml
+++ b/isaac_ros_vda5050_nav2_client/package.xml
@@ -29,6 +29,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <depend>std_msgs</depend>
+  <depend>nav_msgs</depend>
   <depend>nav2_msgs</depend>
   <depend>vda5050_msgs</depend>
   <depend>rclcpp</depend>

--- a/isaac_ros_vda5050_nav2_client/src/vda5050_nav2_client_node.cpp
+++ b/isaac_ros_vda5050_nav2_client/src/vda5050_nav2_client_node.cpp
@@ -66,6 +66,10 @@ Vda5050toNav2ClientNode::Vda5050toNav2ClientNode(
       "battery_state", rclcpp::SensorDataQoS(),
       std::bind(&Vda5050toNav2ClientNode::BatteryStateCallback, this,
       std::placeholders::_1))),
+  odometry_sub_(create_subscription<nav_msgs::msg::Odometry>(
+      "odom", rclcpp::SensorDataQoS(),
+      std::bind(&Vda5050toNav2ClientNode::OdometryCallback, this,
+      std::placeholders::_1))),
   update_feedback_period_(
     declare_parameter<double>("update_feedback_period", 1.0)),
   update_order_id_period_(
@@ -420,6 +424,14 @@ void Vda5050toNav2ClientNode::BatteryStateCallback(
   // battery_health and reach are currently not supported
   agv_state_->battery_state.battery_health = 0;
   agv_state_->battery_state.reach = 0;
+}
+
+void Vda5050toNav2ClientNode::OdometryCallback(
+  const nav_msgs::msg::Odometry::ConstSharedPtr msg)
+{
+  agv_state_->velocity.vx = msg->twist.twist.linear.x;
+  agv_state_->velocity.vy = msg->twist.twist.linear.y;
+  agv_state_->velocity.omega = msg->twist.twist.angular.z;
 }
 
 void Vda5050toNav2ClientNode::InstantActionsCallback(


### PR DESCRIPTION
I have just implemented the velocity information in the status message. It subscribes the topic named "odom" with nav_msgs/Odometry message type. It extracts the velotiy information vx vy omega, and it appends to the agv_state message. 
